### PR TITLE
This commit fixes persistent build errors, including a theme resource…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.1")
     implementation("androidx.navigation:navigation-compose:2.7.7")
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:supportsRtl="true">
         <activity
             android:name=".SplashActivity"
             android:exported="true">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,0 @@
-<resources>
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
-    </style>
-</resources>


### PR DESCRIPTION
… not found error and a DexArchiveMergerException.

The root cause was identified as a dependency conflict between the Compose Material 3 library and the view-based Material Components library.

- The `com.google.android.material:material` dependency has been removed.
- The now-unnecessary `styles.xml` file has been deleted.
- The `android:theme` attribute has been removed from the `AndroidManifest.xml`.

## Summary by Sourcery

Remove the conflicting view-based Material Components dependency and associated theme definitions to resolve persistent build errors.

Bug Fixes:
- Fix persistent build errors including a theme resource not found error and a DexArchiveMergerException caused by a dependency conflict

Enhancements:
- Remove the com.google.android.material:material dependency
- Delete the now-unnecessary styles.xml resource file
- Remove the android:theme attribute from the AndroidManifest.xml