### PR TITLE
Fix OutOfMemoryError when loading large dictionary files

### DIFF
--- a/app/src/main/java/com/hereliesaz/wifihaqueur/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/wifihaqueur/MainViewModel.kt
@@ -147,114 +147,118 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun setDictionary(name: String) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             try {
                 val originalUrlString = dictionaryUrls[name] ?: return@launch
                 val context = getApplication<Application>().applicationContext
                 val file = java.io.File(context.cacheDir, "$name.txt")
 
-                val lines: List<String>
+                val exists = withContext(Dispatchers.IO) {
+                    file.exists() && file.length() > 0
+                }
 
-                if (file.exists() && file.length() > 0) {
-                     withContext(Dispatchers.Main) {
-                        _logMessages.value = _logMessages.value + "Loading cached dictionary: $name"
-                    }
-                    lines = file.readLines()
+                if (exists) {
+                    _logMessages.value = _logMessages.value + "Loading cached dictionary: $name"
                 } else {
-                    withContext(Dispatchers.Main) {
-                        _logMessages.value = _logMessages.value + "Downloading dictionary from: $originalUrlString"
-                        _downloadProgress.value = 0f
-                    }
+                    _logMessages.value = _logMessages.value + "Downloading dictionary from: $originalUrlString"
+                    _downloadProgress.value = 0f
 
-                    val urlString = getGoogleDriveDownloadUrl(originalUrlString)
-                    val url = URL(urlString)
-                    val connection = url.openConnection() as java.net.HttpURLConnection
-                    // Handle further redirects
-                    connection.instanceFollowRedirects = true
-                    connection.connect()
+                    withContext(Dispatchers.IO) {
+                        val urlString = getGoogleDriveDownloadUrl(originalUrlString)
+                        val url = URL(urlString)
+                        val connection = url.openConnection() as java.net.HttpURLConnection
+                        // Handle further redirects
+                        connection.instanceFollowRedirects = true
+                        connection.connect()
 
-                    val fileLength = connection.contentLength
+                        val fileLength = connection.contentLength
 
-                    connection.inputStream.use { input ->
-                        java.io.FileOutputStream(file).use { fileOutput ->
-                            val data = ByteArray(4096)
-                            var total: Long = 0
-                            var count: Int
+                        connection.inputStream.use { input ->
+                            java.io.FileOutputStream(file).use { fileOutput ->
+                                val data = ByteArray(4096)
+                                var total: Long = 0
+                                var count: Int
 
-                            while (input.read(data).also { count = it } != -1) {
-                                total += count.toLong()
-                                if (fileLength > 0) {
-                                    val progress = (total * 100 / fileLength).toFloat() / 100f
-                                    _downloadProgress.value = progress
-                                } else {
-                                    // Indeterminate progress
-                                    _downloadProgress.value = -1f
+                                while (input.read(data).also { count = it } != -1) {
+                                    total += count.toLong()
+                                    if (fileLength > 0) {
+                                        val progress = (total * 100 / fileLength).toFloat() / 100f
+                                        withContext(Dispatchers.Main) {
+                                            _downloadProgress.value = progress
+                                        }
+                                    } else {
+                                        // Indeterminate progress
+                                        withContext(Dispatchers.Main) {
+                                            _downloadProgress.value = -1f
+                                        }
+                                    }
+                                    fileOutput.write(data, 0, count)
                                 }
-                                fileOutput.write(data, 0, count)
                             }
                         }
                     }
-
-                    lines = file.readLines()
                 }
 
-                withContext(Dispatchers.Main) {
-                    _downloadProgress.value = null
-                    _dictionarySource.value = DictionarySource.InMemory(lines)
-                    _dictionary.value = lines // For legacy UI binding if needed
-                    _totalPasswords.value = lines.size.toLong()
-                    _logMessages.value = _logMessages.value + "Dictionary loaded successfully. Ready to use."
+                val count = withContext(Dispatchers.IO) {
+                    file.bufferedReader().useLines { it.count().toLong() }
                 }
+
+                val previewLines = withContext(Dispatchers.IO) {
+                    file.bufferedReader().useLines { it.take(100).toList() }
+                }
+
+                _downloadProgress.value = null
+                _dictionarySource.value = DictionarySource.FileUri(Uri.fromFile(file))
+                _dictionary.value = previewLines // Preview instead of loading entirely in-memory
+                _totalPasswords.value = count
+                _logMessages.value = _logMessages.value + "Dictionary loaded successfully. Ready to use."
             } catch (e: Exception) {
-                withContext(Dispatchers.Main) {
-                    _downloadProgress.value = null
-                    _logMessages.value = _logMessages.value + "Error downloading dictionary: ${e.message}"
-                }
+                _downloadProgress.value = null
+                _logMessages.value = _logMessages.value + "Error downloading dictionary: ${e.message}"
             }
         }
     }
 
     fun setDictionaryFromFile(content: String) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             val lines = content.lines()
-            withContext(Dispatchers.Main) {
-                _dictionarySource.value = DictionarySource.InMemory(lines)
-                _dictionary.value = lines
-                _totalPasswords.value = lines.size.toLong()
-                _logMessages.value = _logMessages.value + "Dictionary loaded from file."
-            }
+            _dictionarySource.value = DictionarySource.InMemory(lines)
+            _dictionary.value = lines
+            _totalPasswords.value = lines.size.toLong()
+            _logMessages.value = _logMessages.value + "Dictionary loaded from file."
         }
     }
 
     fun setDictionaryFromUri(uri: Uri) {
-        viewModelScope.launch(Dispatchers.IO) {
-            withContext(Dispatchers.Main) {
-                _dictionarySource.value = DictionarySource.FileUri(uri)
-                _dictionary.value = emptyList() // clear in-memory preview
-            }
+        viewModelScope.launch {
+            _dictionarySource.value = DictionarySource.FileUri(uri)
+            _dictionary.value = emptyList() // clear in-memory preview
 
             // Calculate total passwords safely using streaming to avoid OOM
             try {
                 val context = getApplication<Application>().applicationContext
-                val inputStream: InputStream? = context.contentResolver.openInputStream(uri)
-                if (inputStream != null) {
-                    var count = 0L
-                    inputStream.bufferedReader().useLines { lines ->
-                        count = lines.count().toLong()
+
+                val count = withContext(Dispatchers.IO) {
+                    val inputStream: InputStream? = context.contentResolver.openInputStream(uri)
+                    if (inputStream != null) {
+                        var streamCount = 0L
+                        inputStream.bufferedReader().useLines { lines ->
+                            streamCount = lines.count().toLong()
+                        }
+                        streamCount
+                    } else {
+                        -1L
                     }
-                    withContext(Dispatchers.Main) {
-                        _totalPasswords.value = count
-                        _logMessages.value = _logMessages.value + "Custom dictionary prepared ($count passwords)."
-                    }
+                }
+
+                if (count != -1L) {
+                    _totalPasswords.value = count
+                    _logMessages.value = _logMessages.value + "Custom dictionary prepared ($count passwords)."
                 } else {
-                    withContext(Dispatchers.Main) {
-                        _logMessages.value = _logMessages.value + "Failed to open dictionary file."
-                    }
+                    _logMessages.value = _logMessages.value + "Failed to open dictionary file."
                 }
             } catch (e: Exception) {
-                withContext(Dispatchers.Main) {
-                    _logMessages.value = _logMessages.value + "Error reading custom dictionary."
-                }
+                _logMessages.value = _logMessages.value + "Error reading custom dictionary."
             }
         }
     }


### PR DESCRIPTION
- Refactored `setDictionary` to stop using `file.readLines()`, preventing massive files from crashing the app due to OOM.
- Added streaming via `bufferedReader().useLines { it.count() }` inside a safe `Dispatchers.IO` block to dynamically count passwords.
- Changed the returned dictionary source to `DictionarySource.FileUri(Uri.fromFile(file))` for efficient read access.
- Generated a safe 100-line preview of the dictionary to populate the UI state `_dictionary.value` without blowing memory.

## Summary by Sourcery

Prevent OutOfMemoryError when loading large dictionary files by streaming file access and avoiding full in-memory loads.

Bug Fixes:
- Avoid crash when loading large cached or downloaded dictionaries by streaming line counting and limiting in-memory previews.
- Ensure custom dictionary files from URI are counted using streaming to prevent excessive memory usage.

Enhancements:
- Switch dictionary handling to use file-backed DictionarySource.FileUri with a small line preview instead of full in-memory storage.
- Simplify coroutine dispatcher usage by performing I/O work within withContext(Dispatchers.IO) while keeping state updates on the main scope.