### PR TITLE
Rename app to WiFi Haqueur

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# WifiHaqueuer - The Unethical but Mostly Ineffectual Brutish WiFi Tool for Haqueurs
+# WiFi Haqueur - The Unethical but Mostly Ineffectual Brutish WiFi Tool for Haqueurs
 
 **"To understand a haqueur, go break something. And then wonder why it's broken."**
 
-WifiHaqueuer is a blunt instrument you can whack a router with using the force of a brute. Based on the original `WiFiHacker` by fsecurify, this tool is designed for upscale script kiddies and the secretarially lazy.
+WiFi Haqueur is a blunt instrument you can whack a router with using the force of a brute. Based on the original `WiFiHacker` by fsecurify, this tool is designed for upscale script kiddies and the secretarially lazy.
 
 **Disclaimer:** This application is definitely not intended for educational or ethical purposes, but we will definitely now say that that's not true and that yes, it is. So, be a good wee one and do not winky face use this tool for any illegal activities nudge nudge. Even if you do, I'm not responsible for your bad behavior. FOR SHAME. 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">WifiHaqueuer</string>
+    <string name="app_name">WiFi Haqueur</string>
 </resources>

--- a/docs/file_documentation.md
+++ b/docs/file_documentation.md
@@ -12,7 +12,7 @@ This file specifies which files and directories should be ignored by Git. This i
 
 ### `README.md`
 
-This file provides an introduction to the WifiHaqueuer project. It includes a description of the project, its features, installation instructions, and credits.
+This file provides an introduction to the WiFi Haqueur project. It includes a description of the project, its features, installation instructions, and credits.
 
 ---
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,5 +21,5 @@ dependencyResolutionManagement {
         }
     }
 }
-rootProject.name = "WifiHaqueuer"
+rootProject.name = "WiFi Haqueur"
 include(":app")


### PR DESCRIPTION
This PR updates the application's display name to "WiFi Haqueur" as requested. It modifies the Android `strings.xml`, Gradle configuration, and the project documentation (`README.md`, `docs/file_documentation.md`). Code identifiers like `WifiHaqueurTheme` and package names are left untouched.

---
*PR created automatically by Jules for task [11248485612918945541](https://jules.google.com/task/11248485612918945541) started by @HereLiesAz*

## Summary by Sourcery

Rename the project and user-facing app name to "WiFi Haqueur" across core configuration and docs.

Enhancements:
- Update Android app display name string to "WiFi Haqueur".
- Rename the Gradle root project to "WiFi Haqueur" for consistency with the new app name.

Documentation:
- Update README and file documentation to refer to the project as "WiFi Haqueur".